### PR TITLE
Support 0.48.0-rc.0

### DIFF
--- a/lib/AppRegistryInjection.js
+++ b/lib/AppRegistryInjection.js
@@ -1,7 +1,7 @@
 import { StyleSheet, View, AppRegistry } from 'react-native';
 import React, { Component } from 'react';
 import StaticContainer from 'static-container';
-import EventEmitter from 'react-native/Libraries/EventEmitter/EventEmitter';
+import EventEmitter from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
 const styles = StyleSheet.create({
     container: {


### PR DESCRIPTION
I'm using `react-native-root-toast`, and after upgrade to 0.48.0-rc.0, I bumped into some issue.

Due to react-native 0.48.0-rc.0's change (this [commit](https://github.com/facebook/react-native/commit/365aea3415fdf3e16a6643862a0bfacf87b2f1d1)), the `EventEmitter`'s path should be fix.

Thank you.
