### PR TITLE
Suggestion: Fix event emitter import without breaking changes

### DIFF
--- a/lib/AppRegistryInjection.js
+++ b/lib/AppRegistryInjection.js
@@ -1,7 +1,7 @@
 import { StyleSheet, View, AppRegistry } from 'react-native';
 import React, { Component } from 'react';
 import StaticContainer from 'static-container';
-import EventEmitter from 'react-native/Libraries/EventEmitter/EventEmitter';
+import EventEmitter from "wolfy87-eventemitter";
 
 const styles = StyleSheet.create({
     container: {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "main": "./lib/SiblingsManager",
     "description": "react native root sibling elements manager",
     "dependencies": {
-        "static-container": "^1.0.0"
+        "static-container": "^1.0.0",
+        "wolfy87-eventemitter": "^5.2.2"
     },
     "keywords": [
         "react-component",


### PR DESCRIPTION
Replace the use of the react native event emitter import by https://github.com/Olical/EventEmitter

Fixes #9 without the need to change version based on react native version.

A few libraries depend on `react-native-root-siblings`, so all of those libraries would have to implement a breaking change.
For instance, we're currently developing https://github.com/bamlab/react-native-form-idable which also uses `react-native-root-toast` and both are dependent on this package. That's why I think it would preferable to avoid a breaking change for a small thing like this.

What do you think @magicismight ?