### PR TITLE
Path Change to EventEmitter for RN 0.48

### DIFF
--- a/lib/AppRegistryInjection.js
+++ b/lib/AppRegistryInjection.js
@@ -1,7 +1,7 @@
 import { StyleSheet, View, AppRegistry } from 'react-native';
 import React, { Component } from 'react';
 import StaticContainer from 'static-container';
-import EventEmitter from 'react-native/Libraries/EventEmitter/EventEmitter';
+import EventEmitter from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
 const styles = StyleSheet.create({
     container: {


### PR DESCRIPTION
Fixes the unable to resolve module 'react-native/Libraries/EventEmitter/EventEmitter' .. that occurs in the newest version of RN