### PR TITLE
EventEmitter import update

### DIFF
--- a/lib/AppRegistryInjection.js
+++ b/lib/AppRegistryInjection.js
@@ -1,7 +1,7 @@
 import { StyleSheet, View, AppRegistry } from 'react-native';
 import React, { Component } from 'react';
 import StaticContainer from 'static-container';
-import EventEmitter from 'react-native/Libraries/EventEmitter/EventEmitter';
+import EventEmitter from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
 const styles = StyleSheet.create({
     container: {


### PR DESCRIPTION
EventEmitter removed from RN in .48. Updated to new location.
Reference: https://github.com/invertase/react-native-firebase/issues/386