### PR TITLE
Update EventEmitter path for react-native 0.49

### DIFF
--- a/lib/AppRegistryInjection.js
+++ b/lib/AppRegistryInjection.js
@@ -1,7 +1,7 @@
 import { StyleSheet, View, AppRegistry } from 'react-native';
 import React, { Component } from 'react';
 import StaticContainer from 'static-container';
-import EventEmitter from 'react-native/Libraries/EventEmitter/EventEmitter';
+import EventEmitter from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
 const styles = StyleSheet.create({
     container: {


### PR DESCRIPTION
This package breaks in the latest version of react due to path change. Please merge and create a new version so that I can update this library https://github.com/jacklam718/react-native-dialog-component also which my app depends on.