### PR TITLE
Fix broken inspector on android

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,9 +61,7 @@ AppRegistry.setWrapperComponentProvider(function () {
       this._updatedSiblings = {};
       return (
         <View style={styles.container}>
-          <StaticContainer shouldUpdate={false}>
-            {this.props.children}
-          </StaticContainer>
+          {this.props.children}
           {elements}
         </View>
       );


### PR DESCRIPTION
When children are wrapped in `StaticContainer` with `shouldUpdate={false}`, the react-native inspector displays only "No style" message instead of the inspected element. Setting `shouldUpdate` to `true` or removing `StaticContainer` fixes the problem.

Tested on android in `react-native@0.53.0`.