### PR TITLE
Add redux as dependency and fix default export to work with Babel 7 and React Native 0.57

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ AppRegistry.setWrapperComponentProvider(function () {
   }
 })
 
-export default class {
+export default RootSiblings class {
   constructor(element, callback, store) {
     const id = uuid++;
     function update(element, callback, store) {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "license": "MIT",
     "description": "react native root sibling elements manager",
     "dependencies": {
-        "static-container": "^1.0.0",
-        "react-redux": "*"
+        "react-redux": "*",
+        "redux": "^4.0.0",
+        "static-container": "^1.0.0"
     },
     "keywords": [
         "react-component",


### PR DESCRIPTION
- Issue #34 