### PR TITLE
Avoid stealing touches from other native modals.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ if (!global.__rootSiblingsInjected) {
   AppRegistry.setWrapperComponentProvider(function() {
     return function RootSiblingsWrapper(props) {
       return (
-        <View style={styles.container}>
+        <View style={styles.container} pointerEvents="box-none">
           {props.children}
           <RootSiblings />
         </View>


### PR DESCRIPTION
With `react-native-navigation`, an overlay with `interceptTouchesOutside=false` is not allowed to pass through the touches because of the wrapper view introduces by `react-native-root-siblings`.
As I've seen in the issues section in `react-native-navigation`, many people ditch libraries like `react-native-popup-dialog` and `react-native-root-toast` due to this issue.