### PR TITLE
Call setState asynchronously to avoid warning

### DIFF
--- a/src/RootSiblings.tsx
+++ b/src/RootSiblings.tsx
@@ -67,12 +67,14 @@ export default class extends Component<RootSiblingsProps, RootSiblingsState> {
         }
 
         this.siblingsPool = siblings;
-        this.setState(
-          {
-            siblings
-          },
-          () => this.invokeCallback(updateCallback)
-        );
+        setImmediate(() => {
+          this.setState(
+            {
+              siblings
+            },
+            () => this.invokeCallback(updateCallback)
+          );
+        });
       }
     );
   }


### PR DESCRIPTION
There is a warning:
```
Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.
```